### PR TITLE
support python 3.6

### DIFF
--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -105,7 +105,7 @@ class SqsListener(object):
                                 QueueUrl=self._queue_url,
                                 ReceiptHandle=receipt_handle
                             )
-                    except Exception, ex:
+                    except Exception as ex:
                         sqs_logger.warning( repr(ex))
                         if self._error_queue_name:
                             exc_type, exc_obj, exc_tb = sys.exc_info()


### PR DESCRIPTION
"except Exception, ex:" is not supported by python 3.6