### PR TITLE
Added long polling support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ Here is a basic code sample:
 - interval (int) - number of seconds in between polls. Set to 60 by default
 - visibility_timeout (str) - Number of seconds the message will be invisible ('in flight') after being read.  After this time interval it reappear in the queue if it wasn't deleted in the meantime.  Set to '600' (10 minutes) by default
 - error_visibility_timeout (str) - Same as previous argument, for the error queue.  Applicable only if the ``error_queue`` argument is set, and the queue doesn't already exist.
+- wait_time (int) - number of seconds in for long polls. Set to 0 by default to provide short polling.
 
 Running as a Daemon
 ~~~~~~~~~~~~~~~~~~~

--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -47,6 +47,7 @@ class SqsListener(object):
         self._attribute_names = kwargs['attribute_names'] if 'attribute_names' in kwargs else []
         self._force_delete = kwargs['force_delete'] if 'force_delete' in kwargs else False
         self._region_name = kwargs['region_name'] if 'region_name' in kwargs else 'us-east-1'
+        self._wait_time = kwargs['wait_time'] if 'wait_time' in kwargs else 0
         # must come last
         self._client = self._initialize_client()
 
@@ -113,10 +114,13 @@ class SqsListener(object):
     def _start_listening(self):
         # TODO consider incorporating output processing from here: https://github.com/debrouwere/sqs-antenna/blob/master/antenna/__init__.py
         while True:
+            # calling with WaitTimeSecconds of zero show the same behavior as
+            # not specifiying a wait time, ie: short polling
             messages = self._client.receive_message(
                 QueueUrl=self._queue_url,
                 MessageAttributeNames=self._message_attribute_names,
                 AttributeNames=self._attribute_names,
+                WaitTimeSeconds=self._wait_time,
             )
             if 'Messages' in messages:
                 sqs_logger.info( str(len(messages['Messages'])) + " messages received")


### PR DESCRIPTION
Hello,

In using your library at work(NewsCycle Solution) I need to support long polling so I added an optional parameter to support it. In my testing the default behavior is not changed with the default value of '0'. Unfortunately the effect of a `WaitTimeSeconds=0` is not documented so I can offer no further support of this not changing the default behavior.
This is my first pull request on GitHub so if any of this is 'off' let me know.

Thanks,
Gabriel Norton