### PR TITLE
Filter for queue in request instead of after.

### DIFF
--- a/sqs_launcher/__init__.py
+++ b/sqs_launcher/__init__.py
@@ -42,7 +42,7 @@ class SqsLauncher(object):
         self._client = self._session.client('sqs')
 
         self._queue_name = queue
-        queues = self._client.list_queues()
+        queues = self._client.list_queues(QueueNamePrefix=self._queue_name)
         exists = False
         for q in queues['QueueUrls']:
             qname = q.split('/')[-1]

--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -59,7 +59,7 @@ class SqsListener(object):
         self._session = boto3.session.Session()
         sqs = self._session.client('sqs', region_name=self._region_name)
 
-        queues = sqs.list_queues()
+        queues = sqs.list_queues(QueueNamePrefix=self._queue_name)
         mainQueueExists = False
         errorQueueExists = False
         if 'QueueUrls' in queues:


### PR DESCRIPTION
When we have more than 1000 queues in an AWS account, list_queues does not paginate.  This means that a queue can be deemed to not exist if it isn't part of the first page.  Instead of iterating over every queue w/ pagination we can just query the prefix and then look at that returned items that match. 