### PR TITLE
Added feature to create SqsListener with separate AWS credentials other than AWS_ACCOUNT_ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 venv
+.mypy_cache
+.vscode
 .idea
 *.pyc
 .DS_Store

--- a/sample_daemon.py
+++ b/sample_daemon.py
@@ -15,7 +15,7 @@ class MyListener(SqsListener):
 
 class MyDaemon(Daemon):
     def run(self):
-        print "Initializing listener"
+        print("Initializing listener")
         listener = MyListener('main-queue', 'error-queue')
         listener.listen()
 
@@ -24,17 +24,17 @@ if __name__ == "__main__":
     daemon = MyDaemon('/var/run/sqs_daemon.pid')
     if len(sys.argv) == 2:
         if 'start' == sys.argv[1]:
-            print "Starting listener daemon"
+            print("Starting listener daemon")
             daemon.start()
         elif 'stop' == sys.argv[1]:
-            print "Attempting to stop the daemon"
+            print("Attempting to stop the daemon")
             daemon.stop()
         elif 'restart' == sys.argv[1]:
             daemon.restart()
         else:
-            print "Unknown command"
+            print("Unknown command")
             sys.exit(2)
         sys.exit(0)
     else:
-        print "usage: %s start|stop|restart" % sys.argv[0]
+        print("usage: %s start|stop|restart" % sys.argv[0])
         sys.exit(2)


### PR DESCRIPTION
Hello,
First of all, thank you for the great wrapper for AWS SQS.

I wanted to use separate AWS credentials other than the one which are loaded in the environment.
It now allows multiple account usage.

Thanks.