### PR TITLE
Remove check for AWS_ACCOUNT_ID.

### DIFF
--- a/sqs_launcher/__init__.py
+++ b/sqs_launcher/__init__.py
@@ -40,9 +40,6 @@ class SqsLauncher(object):
         """
         if not queue and not queue_url:
             raise ValueError('Either `queue` or `queue_url` should be provided.')
-        if (not os.environ.get('AWS_ACCOUNT_ID', None) and
-                not (boto3.Session().get_credentials().method in ['iam-role', 'assume-role'])):
-            raise EnvironmentError('Environment variable `AWS_ACCOUNT_ID` not set and no role found.')
         # new session for each instantiation
         self._session = boto3.session.Session()
         self._client = self._session.client('sqs')

--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -35,9 +35,6 @@ class SqsListener(object):
         :param queue: (str) name of queue to listen to
         :param kwargs: options for fine tuning. see below
         """
-        if (not os.environ.get('AWS_ACCOUNT_ID', None) and
-                not ('iam-role' == boto3.Session().get_credentials().method)):
-            raise EnvironmentError('Environment variable `AWS_ACCOUNT_ID` not set and no role found.')
         self._queue_name = queue
         self._poll_interval = kwargs.get("interval", 60)
         self._queue_visibility_timeout = kwargs.get('visibility_timeout', '600')


### PR DESCRIPTION
The boto3 library is not actually requiring these for my usage. I'm not sure if it ever does. Credentials, when run on the command line, are pulled by boto3 by the ~/aws/credentials file as well as considering the AWS_PROFILE environment variable. When running in ECS the credentials are picked up just fine but AWS_ACCOUNT_ID is not set by the environment so this check needlessly raises exception when it would work. I think it's best to leave the credentials checks to boto3 and let it report what it needs.