### PR TITLE
Implement the ability to pass serialization and deserialization functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,14 +68,14 @@ Here is a basic code sample:
 - attribute_names (list) - attributes by which to filter messages (see boto docs for difference between these two)
 - region_name (str) - AWS region name (defaults to ``us-east-1``)
 - queue_url (str) - overrides ``queue`` parameter. Mostly useful for getting around `this bug <https://github.com/aws/aws-cli/issues/1715>`_ in the boto library
-
+- deserializer (function str -> dict) - Deserialization function that will be used to parse the message body. Set to python's ``json.loads`` by default.
 
 Running as a Daemon
 ~~~~~~~~~~~~~~~~~~~
 
 | Typically, in a production environment, you'll want to listen to an SQS queue with a daemonized process.
   The simplest way to do this is by running the listener in a detached process.  On a typical Linux distribution it might look   like this:
-|  
+|
   ``nohup python my_listener.py > listener.log &``
 |  And saving the resulting process id for later (for stopping the listener via the ``kill`` command).
 |
@@ -131,7 +131,9 @@ Sending messages
 | In order to send a message, instantiate an ``SqsLauncher`` with the name of the queue.  By default an exception will
   be raised if the queue doesn't exist, but it can be created automatically if the ``create_queue`` parameter is
   set to true.  In such a case, there's also an option to set the newly created queue's ``VisibilityTimeout`` via the
-  third parameter.
+  third parameter. It is possible to provide a ``serializer`` function if custom types need to be sent. This function
+  expects a dict object and should return a string. If not provided, python's `json.dumps` is used by default.
+
 |
 | After instantiation, use the ``launch_message()`` method to send the message.  The message body should be a ``dict``,
   and additional kwargs can be specified as stated in the `SQS docs

--- a/sqs_launcher/__init__.py
+++ b/sqs_launcher/__init__.py
@@ -27,7 +27,7 @@ sqs_logger = logging.getLogger('sqs_listener')
 
 class SqsLauncher(object):
 
-    def __init__(self, queue=None, queue_url=None, create_queue=False, visibility_timeout='600'):
+    def __init__(self, queue=None, queue_url=None, create_queue=False, visibility_timeout='600', serializer=json.dumps):
         """
         :param queue: (str) name of queue to listen to
         :param queue_url: (str) url of queue to listen to
@@ -38,7 +38,7 @@ class SqsLauncher(object):
                                     to finish execution. See http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
                                     for more information
         """
-        if not any(queue, queue_url):
+        if not any([queue, queue_url]):
             raise ValueError('Either `queue` or `queue_url` should be provided.')
         if (not os.environ.get('AWS_ACCOUNT_ID', None) and
                 not (boto3.Session().get_credentials().method in ['iam-role', 'assume-role'])):
@@ -49,6 +49,8 @@ class SqsLauncher(object):
 
         self._queue_name = queue
         self._queue_url = queue_url
+        self._serializer = serializer
+
         if not queue_url:
             queues = self._client.list_queues(QueueNamePrefix=self._queue_name)
             exists = False
@@ -83,8 +85,8 @@ class SqsLauncher(object):
         sqs_logger.info("Sending message to queue " + self._queue_name)
         return self._client.send_message(
             QueueUrl=self._queue_url,
-            MessageBody=json.dumps(message),
-            **kwargs,
+            MessageBody=self._serializer(message),
+            **kwargs
         )
 
     def _get_queue_name_from_url(self, url):

--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -38,6 +38,7 @@ class SqsListener(object):
         aws_access_key = kwargs.get('aws_access_key', '')
         aws_secret_key = kwargs.get('aws_secret_key', '')
 
+        boto3_session = None
         if len(aws_access_key) != 0 and len(aws_secret_key) != 0:
             boto3_session = boto3.Session(
                 aws_access_key_id=aws_access_key,
@@ -60,6 +61,7 @@ class SqsListener(object):
         self._endpoint_name = kwargs.get('endpoint_name', None)
         self._wait_time = kwargs.get('wait_time', 0)
         self._max_number_of_messages = kwargs.get('max_number_of_messages', 1)
+        self._deserializer = kwargs.get("deserializer", json.loads)
 
         # must come last
         if boto3_session:
@@ -89,7 +91,7 @@ class SqsListener(object):
                     errorQueueExists = True
 
 
-        # create queue if necessary. 
+        # create queue if necessary.
         # creation is idempotent, no harm in calling on a queue if it already exists.
         if self._queue_url is None:
             if not mainQueueExists:
@@ -155,12 +157,13 @@ class SqsListener(object):
                     message_attribs = None
                     attribs = None
 
-                    # catch problems with malformed JSON, usually a result of someone writing poor JSON directly in the AWS console
                     try:
-                        params_dict = json.loads(m_body)
-                    except:
-                        sqs_logger.warning("Unable to parse message - JSON is not formatted properly")
+                        deserialized = self._deserializer(m_body)
+                    except Exception as e:
+                        sqs_logger.error("Unable to parse message")
+                        sqs_logger.exception(e)
                         continue
+
                     if 'MessageAttributes' in m:
                         message_attribs = m['MessageAttributes']
                     if 'Attributes' in m:
@@ -171,9 +174,9 @@ class SqsListener(object):
                                 QueueUrl=self._queue_url,
                                 ReceiptHandle=receipt_handle
                             )
-                            self.handle_message(params_dict, message_attribs, attribs)
+                            self.handle_message(deserialized, message_attribs, attribs)
                         else:
-                            self.handle_message(params_dict, message_attribs, attribs)
+                            self.handle_message(deserialized, message_attribs, attribs)
                             self._client.delete_message(
                                 QueueUrl=self._queue_url,
                                 ReceiptHandle=receipt_handle


### PR DESCRIPTION
Hello,

This merge request includes the following changes:

# Serialization

* Add the possibility to pass a "deserialization" function to the listener. The default behavior has not been altered. By default json.loads is used. This would allow a client to use formats other than json, but if they choose to do so, they have to provide their own handling function. (This is the change that pushed me to make these changes, since I needed to handle other formats than json)

* Log the stacktrace of the error in case something happens during deserialization. I thought this might be more useful during debugging than the previous message, since the error could now be anything.

* Add the possibility to pass a "serialization" function to the "launcher". This allows the client for example to use custom types in their dictionary, and then provide the proper serialization function that knows how to handle those types where a `json.dumps` would fail.

* Update README to reflect these changes.

# Python 2.7 compatibility

* wrap queue and queue_url in a list before passing it to the `any` function in the launcher constructor.
* Remove trailing comma at line 87 (old) / 89 (new) of the launcher (the trailing comma causes an error at runtime on python 2.7).
* Initialize the `boto3_session` variable in the constructor before the blocks that can set / inspect its value. "Variable used before being declared" errors would pop up otherwise.

These "compatibility" changes are pretty minor, and allow for the library to still be used by python 2.7.

---

Please feel free to tell me if anything is unclear or you wish to discuss or change something in the proposed merge request.

Regards,
