### PR TITLE
handle ValueError exception when pidfile is empty

### DIFF
--- a/sqs_listener/daemon.py
+++ b/sqs_listener/daemon.py
@@ -86,6 +86,8 @@ class Daemon:
             pf.close()
         except IOError:
             pid = None
+        except ValueError:
+            pid = None
 
         if pid:
             message = "pidfile %s already exist. Daemon already running?\n"
@@ -112,6 +114,8 @@ class Daemon:
             pid = int(pf.read().strip())
             pf.close()
         except IOError:
+            pid = None
+        except ValueError:
             pid = None
 
         if not pid:


### PR DESCRIPTION
When starting the Daemon for the first time, the pidfile is auto-created with empty content, however, the exception handling does not capture casting an empty string to int.

Currently, the following exception is raised.
```
Traceback (most recent call last):
  File "callback_listener.py", line 46, in <module>
    daemon.start()
  File "~/sqs_listener/daemon.py", line 85, in start
    pid = int(pf.read().strip())
ValueError: invalid literal for int() with base 10: ''
```
