### PR TITLE
[issue #54] Fixed auth compatibility with EKS serviceAccount roles

### DIFF
--- a/sqs_launcher/__init__.py
+++ b/sqs_launcher/__init__.py
@@ -40,9 +40,13 @@ class SqsLauncher(object):
         """
         if not any((queue, queue_url)):
             raise ValueError('Either `queue` or `queue_url` should be provided.')
-        if (not os.environ.get('AWS_ACCOUNT_ID', None) and
-                not (boto3.Session().get_credentials().method in ['iam-role', 'assume-role'])):
+        
+        if (
+            not os.environ.get('AWS_ACCOUNT_ID', None) and 
+            not (boto3.Session().get_credentials().method in ['iam-role', 'assume-role', 'assume-role-with-web-identity'])
+        ):
             raise EnvironmentError('Environment variable `AWS_ACCOUNT_ID` not set and no role found.')
+        
         # new session for each instantiation
         self._session = boto3.session.Session()
         self._client = self._session.client('sqs')

--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -45,8 +45,10 @@ class SqsListener(object):
             )
         else:
             boto3_session = None
-            if (not os.environ.get('AWS_ACCOUNT_ID', None) and
-                    not ('iam-role' == boto3.Session().get_credentials().method)):
+            if (
+                not os.environ.get('AWS_ACCOUNT_ID', None) and 
+                not (boto3.Session().get_credentials().method in ['iam-role', 'assume-role', 'assume-role-with-web-identity'])
+            ):
                 raise EnvironmentError('Environment variable `AWS_ACCOUNT_ID` not set and no role found.')
 
         self._queue_name = queue


### PR DESCRIPTION
In EKS environments, each container on a single host can have its own credentials.
Authentication is supported via a mechanism of 'serviceAccounts' (a kubernetes term).

`boto3.Session().get_credentials().method` returns assume-role-with-web-identity which is another form of iam role based credentials.

Current implementation only allows` iam-role`, `assume-role` but not `assume-role-with-web-identity`.