### PR TITLE
adding stop functionality for graceful shutdown

### DIFF
--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -200,8 +200,11 @@ class SqsListener(object):
                             )
 
             else:
+                if not self._should_listen:
+                    break
                 time.sleep(self._poll_interval)
         sqs_logger.info("client is not in listening state, stopping sqs listener")
+
     def listen(self):
         self._should_listen = True
         sqs_logger.info("Listening to queue " + self._queue_name)
@@ -209,8 +212,10 @@ class SqsListener(object):
             sqs_logger.info("Using error queue " + self._error_queue_name)
 
         self._start_listening()
+
     def stop(self):
         self._should_listen = False
+
     def _prepare_logger(self):
         logger = logging.getLogger('eg_daemon')
         logger.setLevel(logging.INFO)

--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -66,6 +66,7 @@ class SqsListener(object):
         self._wait_time = kwargs.get('wait_time', 0)
         self._max_number_of_messages = kwargs.get('max_number_of_messages', 1)
         self._deserializer = kwargs.get("deserializer", json.loads)
+        self.should_run = False
 
         # must come last
         if boto3_session:
@@ -138,8 +139,9 @@ class SqsListener(object):
         return sqs
 
     def _start_listening(self):
+        self.should_run = True
         # TODO consider incorporating output processing from here: https://github.com/debrouwere/sqs-antenna/blob/master/antenna/__init__.py
-        while True:
+        while self.should_run:
             # calling with WaitTimeSecconds of zero show the same behavior as
             # not specifiying a wait time, ie: short polling
             messages = self._client.receive_message(
@@ -205,7 +207,8 @@ class SqsListener(object):
             sqs_logger.info("Using error queue " + self._error_queue_name)
 
         self._start_listening()
-
+    def stop(self):
+        self.should_run = False
     def _prepare_logger(self):
         logger = logging.getLogger('eg_daemon')
         logger.setLevel(logging.INFO)

--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -66,7 +66,7 @@ class SqsListener(object):
         self._wait_time = kwargs.get('wait_time', 0)
         self._max_number_of_messages = kwargs.get('max_number_of_messages', 1)
         self._deserializer = kwargs.get("deserializer", json.loads)
-        self.should_run = False
+        self._should_listen = False
 
         # must come last
         if boto3_session:
@@ -139,9 +139,8 @@ class SqsListener(object):
         return sqs
 
     def _start_listening(self):
-        self.should_run = True
         # TODO consider incorporating output processing from here: https://github.com/debrouwere/sqs-antenna/blob/master/antenna/__init__.py
-        while self.should_run:
+        while self._should_listen:
             # calling with WaitTimeSecconds of zero show the same behavior as
             # not specifiying a wait time, ie: short polling
             messages = self._client.receive_message(
@@ -156,6 +155,8 @@ class SqsListener(object):
                 sqs_logger.debug(messages)
                 sqs_logger.info("{} messages received".format(len(messages['Messages'])))
                 for m in messages['Messages']:
+                    if not self._should_listen:
+                        break
                     receipt_handle = m['ReceiptHandle']
                     m_body = m['Body']
                     message_attribs = None
@@ -200,15 +201,16 @@ class SqsListener(object):
 
             else:
                 time.sleep(self._poll_interval)
-
+        sqs_logger.info("client is not in listening state, stopping sqs listener")
     def listen(self):
+        self._should_listen = True
         sqs_logger.info("Listening to queue " + self._queue_name)
         if self._error_queue_name:
             sqs_logger.info("Using error queue " + self._error_queue_name)
 
         self._start_listening()
     def stop(self):
-        self.should_run = False
+        self._should_listen = False
     def _prepare_logger(self):
         logger = logging.getLogger('eg_daemon')
         logger.setLevel(logging.INFO)


### PR DESCRIPTION
- adding an internal variable `_should_listen` for managing the state of the endless for loop
  - this variable also will stop the messages loop in case there are many messages received in the batch
- exposing a `stop` function to stop listening and making the `listen` function to return