### PR TITLE
add sso to list of accepted auth methods

### DIFF
--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -49,7 +49,7 @@ class SqsListener(object):
             boto3_session = None
             if (
                     not os.environ.get('AWS_ACCOUNT_ID', None) and
-                    not (boto3.Session().get_credentials().method in ['iam-role', 'assume-role', 'assume-role-with-web-identity'])
+                    not (boto3.Session().get_credentials().method in ['sso', 'iam-role', 'assume-role', 'assume-role-with-web-identity'])
             ):
                 raise EnvironmentError('Environment variable `AWS_ACCOUNT_ID` not set and no role found.')
 


### PR DESCRIPTION
Our company uses this project to connect with SQS Queues, but we use SSO login to auth with AWS locally instead of an IAM role. This adds `sso` as an acceptable auth method.